### PR TITLE
pick up cmake minimum version from top level CMakeLists

### DIFF
--- a/MyCMakeProject/tests/CMakeLists.txt
+++ b/MyCMakeProject/tests/CMakeLists.txt
@@ -1,6 +1,8 @@
 cmake_minimum_required(VERSION 3.6)
 project(unit_tests)
 
+# Set the minimum required cmake version to the included CMakeLists.txt.in file for GTest
+set(gtest_cmake_minimum_required_version ${CMAKE_MINIMUM_REQUIRED_VERSION})
 # Download and unpack googletest at configure time
 configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
 execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .

--- a/MyCMakeProject/tests/CMakeLists.txt.in
+++ b/MyCMakeProject/tests/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 2.8.2)
+cmake_minimum_required(VERSION @gtest_cmake_minimum_required_version@)
 
 project(googletest-download NONE)
 


### PR DESCRIPTION
This passes up the last used `cmake_minimum_required VERSION` passed to CMake and passes it as a variable to the included `CMakeLists.txt.in` file for GTest keeping the versioning consistent